### PR TITLE
feat: prefer headless, add tons of options

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,15 @@ Maintenance Status: Stable
 **Table of Contents**
 
 - [Installation](#installation)
+- [Options](#options)
+  - [`browsers`](#browsers)
+  - [`preferHeadless`](#preferheadless)
+  - [`detectBrowsers`](#detectbrowsers)
+  - [`serverBrowsers`](#serverbrowsers)
+  - [`customLaunchers`](#customlaunchers)
+  - [`teamcityLaunchers`](#teamcitylaunchers)
+  - [`travisLaunchers`](#travislaunchers)
+  - [`browserstackLaunchers`](#browserstacklaunchers)
 - [Code Coverage](#code-coverage)
   - [codecov.io](#codecovio)
   - [View the html report](#view-the-html-report)
@@ -38,10 +47,254 @@ Then in your karma config do
 ```js
 const generateKarmaConfig = require('videojs-generate-karma-config');
 
-module.exports = function(config) {
-  config = generateKarmaConfig(config);
+module.exports = function(karmaConfig) {
+  const options = {};
+
+  config = generateKarmaConfig(config, options);
 };
 ```
+
+## Options
+By default all options are passed as the second argument to generateKarmaConfig.
+
+### `browsers`
+
+> Type: `Function`
+> Default: `none`
+
+> NOTE: Be very careful with this option, this will effect ci runs as well.
+
+A function that should take one argument, the array of browsers that are about to run, and return an array of browsers that should run. This is used to manually overide the browsers that should run.
+
+Example with detected browsers:
+
+```js
+module.exports = function(karmaConfig) {
+  const options = {
+    browsers(aboutToRun) {
+      const safariIndex = aboutToRun.indexOf('Safari');
+
+      // never test on Safari
+      if (safariIndex !== -1) {
+        aboutToRun.splice(safariIndex, 1)
+      }
+
+      return aboutToRun;
+    }
+  };
+
+  config = generateKarmaConfig(config, options);
+};
+```
+
+### `preferHeadless`
+
+> Type: `Boolean`
+> Default: `true`
+
+If we should prefer running headless browsers. This will change the defaults for `travisLaunchers` and `serverBrowsers` as well as automatic browser detection. Make sure to handle this in [`postDetection`](###postDetection)
+
+### `detectBrowsers`
+
+> Type: `Boolean`
+> Default: `true`
+
+> Note: If you set this to false, you will probably want to provide browsers using the [`browsers`](###browsers) option.
+
+If we should detect browsers to run automatically. This will only be done when:
+1. We are not running ci browsers (teamcity, browserstack, or travis)
+2. We are not running in `serverMode` (`--no-single-run` passed to karma cli)
+
+### `serverBrowsers`
+
+> Type: `Function`
+> Default: `none`
+
+A function that should return an array of browsers that should run when in static server mode (--single-run=false). It should take one argument: The default serverBrowsers array which is `['ChromeHeadless']` if [`preferHeadless`](###preferHeadless) is true and `['Chrome']` otherwise.
+
+Example:
+
+```js
+module.exports = function(karmaConfig) {
+  const options = {
+    serverBrowsers(defaults) {
+      serverBrowsers.push('myTestLauncher');
+
+      return serverBrowsers;
+    }
+  };
+
+  config = generateKarmaConfig(config, options);
+};
+```
+
+### `customLaunchers`
+
+> Type: `Function`
+> Default: `none`
+
+A function that should return an object of karma custom launchers. It should take one argument: The default custom launchers object which is: `{}`;
+
+Example:
+
+```js
+module.exports = function(karmaConfig) {
+  const options = {
+    customLaunchers(defaults) {
+      return Object.assign(defaults, {
+        myTestLauncher: {
+          base: 'ChromeHeadless'
+        }
+      };
+    }
+  };
+
+  config = generateKarmaConfig(config, options);
+};
+```
+
+### `teamcityLaunchers`
+
+> Type: `Function`
+> Default: `none`
+
+> NOTE: All browsers contained from this object will be run on teamcity, even with BROWSER_STACK_USERNAME in the enviornment!
+
+A function that should return an object of karma custom launchers, that should be run on teamcity. It should take one argument: The default custom launchers object which is: `{}`;
+
+Example:
+
+```js
+module.exports = function(karmaConfig) {
+  const options = {
+    teamcityLaunchers(defaults) {
+      // add another browser to teamcity testing
+      return Object.assign(defaults, {
+        myTestLauncher: {
+          base: 'ChromeHeadless'
+        }
+      };
+    }
+  };
+
+  config = generateKarmaConfig(config, options);
+};
+```
+
+### `travisLaunchers`
+
+> Type: `Function`
+> Default: `none`
+
+> NOTE: All browsers contained from this object will be run on travis, even with BROWSER_STACK_USERNAME in the enviornment!
+
+A function that should return an object containing karma custom launchers, that should all be run on travis. It should take one argument: The default travis launchers object which is:
+
+> Note: the base will change to non-headless browsers if [`preferHeadless`](###preferHeadless) is set to false.
+```js
+{
+  travisFirefox: {
+    base: 'FirefoxHeadless'
+  },
+  travisChrome: {
+    base: 'ChromeHeadless',
+    flags: ['--no-sandbox']
+  }
+
+}
+```
+
+Example:
+
+```js
+module.exports = function(karmaConfig) {
+  const options = {
+    travisLaunchers(defaults) {
+      // add another browser to travis testing
+      return Object.assign(defaults, {
+        myTestLauncher: {
+          base: 'ChromeHeadless'
+        }
+      };
+    }
+  };
+
+  config = generateKarmaConfig(config, options);
+};
+```
+
+### `browserstackLaunchers`
+
+> Type: `Function`
+> Default: `none`
+
+> NOTE: all browsers contained in this list will be run if there is an enviornment variable called BROWSER_STACK_USERNAME present!
+
+A function that should return an object containing karma custom launchers, that should all be run on browserstack. It should take one argument: The default browserstack launchers object which is:
+```js
+{
+  bsChrome: {
+    base: 'BrowserStack',
+    browser: 'chrome',
+    os: 'Windows',
+    os_version: '10'
+  },
+
+  bsFirefox: {
+    base: 'BrowserStack',
+    browser: 'firefox',
+    os: 'Windows',
+    os_version: '10'
+  },
+
+  bsSafariSierra: {
+    base: 'BrowserStack',
+    browser: 'safari',
+    os: 'OS X',
+    os_version: 'Sierra'
+  },
+
+  bsEdgeWin10: {
+    base: 'BrowserStack',
+    browser: 'edge',
+    os: 'Windows',
+    os_version: '10'
+  },
+
+  bsIE11Win10: {
+    base: 'BrowserStack',
+    browser: 'ie',
+    browser_version: '11',
+    os: 'Windows',
+    os_version: '10'
+  },
+
+  bsIE11Win7: {
+    base: 'BrowserStack',
+    browser: 'ie',
+    browser_version: '11',
+    os: 'Windows',
+    os_version: '7'
+  }
+}
+```
+
+```js
+module.exports = function(karmaConfig) {
+  const options = {
+    BrowserstackLaunchers(defaults) {
+      // only test on Edge windows 10
+      return {
+        bsEdgeWin10: defaults.bsEdgeWin10;
+      };
+    }
+  };
+
+  config = generateKarmaConfig(config, options);
+};
+```
+
+For more information on [browserstack launchers see the docs](https://github.com/karma-runner/karma-browserstack-launcher).
 
 ## Code Coverage
 lcov, json, and html coverage reports will be generated in `test/dist/coverage` after a test run.
@@ -51,7 +304,7 @@ lcov, json, and html coverage reports will be generated in `test/dist/coverage` 
 2. run `codecov -f test/dist/coverage/lcov.info` on your ci after testing
 
 ### View the html report
-> NOTE: When running as a static server you will have to generate the coverage report by going to `localhost:9999/test` before you can visit the coverage report.
+> NOTE: When running as a static server the "serverBrowsers" will have to finish running before you see this. See [serverBrowsers](###serverBrowsers)
 1. Run your unit tests
 2. open `test/dist/coverage/index.html`
 

--- a/README.md
+++ b/README.md
@@ -72,14 +72,10 @@ Example with detected browsers:
 module.exports = function(karmaConfig) {
   const options = {
     browsers(aboutToRun) {
-      const safariIndex = aboutToRun.indexOf('Safari');
-
       // never test on Safari
-      if (safariIndex !== -1) {
-        aboutToRun.splice(safariIndex, 1)
-      }
-
-      return aboutToRun;
+      return aboutToRun.filter(function(launcherName) {
+        return launcherName !== 'Safari';
+      });
     }
   };
 
@@ -158,7 +154,7 @@ module.exports = function(karmaConfig) {
 > Type: `Function`
 > Default: `none`
 
-> NOTE: All browsers contained from this object will be run on teamcity, even with BROWSER_STACK_USERNAME in the enviornment!
+> NOTE: All browsers contained from this object will be run on teamcity, unless BROWSER_STACK_USERNAME is in the enviornment!
 
 A function that should return an object of karma custom launchers, that should be run on teamcity. It should take one argument: The default custom launchers object which is: `{}`;
 
@@ -186,7 +182,7 @@ module.exports = function(karmaConfig) {
 > Type: `Function`
 > Default: `none`
 
-> NOTE: All browsers contained from this object will be run on travis, even with BROWSER_STACK_USERNAME in the enviornment!
+> NOTE: All browsers contained from this object will be run on travis, unless BROWSER_STACK_USERNAME is in the enviornment!
 
 A function that should return an object containing karma custom launchers, that should all be run on travis. It should take one argument: The default travis launchers object which is:
 

--- a/index.js
+++ b/index.js
@@ -1,14 +1,18 @@
 /* eslint-disable no-console, camelcase */
 const path = require('path');
-const karmaPlugins = [];
+const karmaPlugins = ['karma-*'];
 const libPkg = require('./package.json');
 
-// dynamically require  all local karma plugins
+// dynamically require karma plugins from `videojs-generate-karma-config`
+// as karma-* only works on project local plugins.
 Object.keys(libPkg.dependencies).forEach(function(p) {
   if ((/^karma-/).test(p)) {
     karmaPlugins.push(require(p));
   }
 });
+
+/* shared base browsers */
+const customLaunchers = {};
 
 /* browsers to run on teamcity */
 const teamcityLaunchers = {};
@@ -63,16 +67,84 @@ const browserstackLaunchers = {
 /* browsers to run on travis */
 const travisLaunchers = {
   travisFirefox: {
-    base: 'Firefox'
+    base: 'FirefoxHeadless'
   },
   travisChrome: {
-    base: 'Chrome',
+    base: 'ChromeHeadless',
     flags: ['--no-sandbox']
   }
 };
 
-module.exports = function(config) {
+module.exports = function(config, options = {}) {
   const pkg = require(path.join(process.cwd(), 'package.json'));
+
+  // set defaults
+  const settings = {
+    serverBrowsers: ['ChromeHeadless'],
+    customLaunchers,
+    travisLaunchers,
+    browserstackLaunchers,
+    teamcityLaunchers,
+    preferHeadless: true,
+    browsers: (browsers) => browsers,
+    detectBrowsers: true,
+    files: [
+      'node_modules/video.js/dist/video-js.css',
+      'dist/*.css',
+      'node_modules/sinon/pkg/sinon.js',
+      'node_modules/video.js/dist/video.js',
+      'test/dist/bundle.js'
+    ]
+  };
+
+  // options that are passed as values
+  ['detectBrowsers', 'preferHeadless', 'browsers'].forEach(function(k) {
+    if (typeof options[k] !== 'undefined') {
+      settings[k] = options[k];
+    }
+  });
+
+  // if prefer headless is false, set defalts to non headless browsers
+  if (settings.preferHeadless === false) {
+    settings.serverBrowsers = ['Chrome'];
+    settings.travisLaunchers = {
+      travisFirefox: {
+        base: 'Firefox'
+      },
+      travisChrome: {
+        base: 'Chrome',
+        flags: ['--no-sandbox']
+      }
+    };
+  }
+
+  // options that are passed as functions
+  [
+    'customLaunchers',
+    'travisLaunchers',
+    'browserstackLaunchers',
+    'teamcityLaunchers',
+    'serverBrowsers',
+    'files'
+  ].forEach(function(k) {
+    if (!options[k]) {
+      return;
+    }
+
+    // pass default settings to the options function
+    settings[k] = options[k](settings[k]);
+  });
+
+  // detect if we are being run in "server mode" with --no-single-run
+  let serverMode = false;
+
+  for (let i = 0; i < process.argv.length; i++) {
+    const arg = process.argv[i];
+
+    if ((/^(--no-single-run|--noSingleRun|--no-singleRun|--single-run=false|--singleRun=false)$/i).test(arg)) {
+      serverMode = true;
+    }
+  }
 
   config.set({
     frameworks: ['qunit', 'detectBrowsers'],
@@ -83,16 +155,18 @@ module.exports = function(config) {
       {match: '.*', name: 'Expires', value: '0'}
     ],
     customLaunchers: Object.assign(
-      {},
-      travisLaunchers,
-      teamcityLaunchers,
-      browserstackLaunchers
+      settings.customLaunchers,
+      settings.travisLaunchers,
+      settings.teamcityLaunchers,
+      settings.browserstackLaunchers
     ),
     client: {clearContext: false, qunit: {showUI: true, testTimeout: 5000}},
 
     detectBrowsers: {
+      preferHeadless: settings.preferHeadless,
       enabled: false,
-      usePhantomJS: false
+      usePhantomJS: false,
+      postDetection: settings.browsers
     },
     browserStack: {
       project: process.env.TEAMCITY_PROJECT_NAME || pkg.name,
@@ -118,13 +192,7 @@ module.exports = function(config) {
         {type: 'text', dir: '.', subdir: 'test/dist/coverage', file: 'text.txt'}
       ]
     },
-    files: [
-      'node_modules/video.js/dist/video-js.css',
-      'dist/*.css',
-      'node_modules/sinon/pkg/sinon.js',
-      'node_modules/video.js/dist/video.js',
-      'test/dist/bundle.js'
-    ],
+    files: settings.files,
     port: 9999,
     urlRoot: '/test/',
     middleware: ['staticServer'],
@@ -133,20 +201,29 @@ module.exports = function(config) {
     autoWatch: false,
     singleRun: true,
     concurrency: Infinity,
-
+    browserDisconnectTolerance: 3,
     captureTimeout: 30000,
     browserNoActivityTimeout: 300000
   });
 
   /* dynamic configuration, for ci and detectBrowsers */
 
+  let ciBrowsers = [];
+
   // determine what browsers should be run on this environment
   if (process.env.BROWSER_STACK_USERNAME) {
-    config.browsers = Object.keys(browserstackLaunchers);
-  } else if (process.env.TRAVIS) {
-    config.browsers = Object.keys(travisLaunchers);
+    ciBrowsers = ciBrowsers.concat(Object.keys(settings.browserstackLaunchers));
+  }
+
+  if (process.env.TRAVIS) {
+    ciBrowsers = ciBrowsers.concat(Object.keys(settings.travisLaunchers));
   } else if (process.env.TEAMCITY_VERSION) {
-    config.browsers = Object.keys(teamcityLaunchers);
+    ciBrowsers = ciBrowsers.concat(Object.keys(settings.teamcityLaunchers));
+  }
+
+  // ci browsers override all other brosers
+  if (ciBrowsers.length) {
+    config.browsers = ciBrowsers;
   }
 
   // if running on travis
@@ -168,10 +245,21 @@ module.exports = function(config) {
     config.browserStack.name += process.env.BUILD_NUMBER;
   }
 
-  // If no browsers are specified, we enable `karma-detect-browsers`
-  // this will detect all browsers that are available for testing
-  if (config.browsers !== false && !config.browsers.length) {
+  // in "server mode" if we have "serverBrowsers"
+  if (serverMode && settings.serverBrowsers) {
+    config.browsers = settings.serverBrowsers;
+
+  // if detect browsers is not explicitly disabled, turn it on
+  } else if (settings.detectBrowsers !== false && config.browsers !== false && !config.browsers.length) {
     config.detectBrowsers.enabled = true;
+
+  // otherwise
+  } else if (settings.browsers) {
+    // if browsers is a boolean convert it to an array so postDetection is not confusing
+    if (!Array.isArray(config.browsers)) {
+      config.browsers = [];
+    }
+    config.browsers = settings.browsers(config.browsers);
   }
 
   return config;

--- a/index.js
+++ b/index.js
@@ -208,22 +208,13 @@ module.exports = function(config, options = {}) {
 
   /* dynamic configuration, for ci and detectBrowsers */
 
-  let ciBrowsers = [];
-
   // determine what browsers should be run on this environment
   if (process.env.BROWSER_STACK_USERNAME) {
-    ciBrowsers = ciBrowsers.concat(Object.keys(settings.browserstackLaunchers));
-  }
-
-  if (process.env.TRAVIS) {
-    ciBrowsers = ciBrowsers.concat(Object.keys(settings.travisLaunchers));
+    config.browsers = Object.keys(settings.browserstackLaunchers);
+  } else if (process.env.TRAVIS) {
+    config.browsers = Object.keys(settings.travisLaunchers);
   } else if (process.env.TEAMCITY_VERSION) {
-    ciBrowsers = ciBrowsers.concat(Object.keys(settings.teamcityLaunchers));
-  }
-
-  // ci browsers override all other brosers
-  if (ciBrowsers.length) {
-    config.browsers = ciBrowsers;
+    config.browsers = Object.keys(settings.teamcityLaunchers);
   }
 
   // if running on travis

--- a/package-lock.json
+++ b/package-lock.json
@@ -236,7 +236,7 @@
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
@@ -4266,7 +4266,7 @@
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
@@ -4324,7 +4324,7 @@
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
@@ -4378,7 +4378,7 @@
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
@@ -4699,7 +4699,7 @@
     },
     "mkdirp": {
       "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
       "requires": {
         "minimist": "0.0.8"
@@ -4793,7 +4793,7 @@
         },
         "chalk": {
           "version": "0.4.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
+          "resolved": "http://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
           "integrity": "sha1-UZmj3c0MHv4jvAjBsCewYXbgxk8=",
           "dev": true,
           "requires": {
@@ -5011,7 +5011,7 @@
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {


### PR DESCRIPTION
This will be another breaking change, but it should be the last one for awhile. Here are the changes:
1. Add options so configuration is easier to work with
2. Run travis/teamcity browsers alongside browserstack
3. Prefer headless browser versions of chrome/firefox
4. Run a headless browser in server mode to get automatic test feedback and so that the html coverage report will always be available.