### PR TITLE
feat: remove IE11 Win7 from testing

### DIFF
--- a/index.js
+++ b/index.js
@@ -72,16 +72,6 @@ const browserstackLaunchers = {
     'os_version': '10',
     'browserstack.local': 'false',
     'browserstack.video': 'false'
-  },
-
-  bsIE11Win7: {
-    'base': 'BrowserStack',
-    'browser': 'ie',
-    'browser_version': '11',
-    'os': 'Windows',
-    'os_version': '7',
-    'browserstack.local': 'false',
-    'browserstack.video': 'false'
   }
 };
 


### PR DESCRIPTION
IE11 on Win7 is producing a lot of failed builds for little benefit.
Instead, we remove this from the build. IE11 on Win10 is still included
and should generally let us test IE11 in a similar capacity.

BREAKING CHANGE: Remove IE11 Win7