### PR TITLE
feat: update browser/os versions

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,7 +20,7 @@ const browserstackLaunchers = {
     'base': 'BrowserStack',
     'browser': 'chrome',
     'os': 'Windows',
-    'os_version': '10',
+    'os_version': '11',
     'browserstack.local': 'false',
     'browserstack.video': 'false'
   },
@@ -29,16 +29,16 @@ const browserstackLaunchers = {
     'base': 'BrowserStack',
     'browser': 'firefox',
     'os': 'Windows',
-    'os_version': '10',
+    'os_version': '11',
     'browserstack.local': 'false',
     'browserstack.video': 'false'
   },
 
-  bsSafari12: {
+  bsSafari16: {
     'base': 'BrowserStack',
     'browser': 'safari',
     'os': 'OS X',
-    'os_version': 'Mojave',
+    'os_version': 'Ventura',
     'browserstack.local': 'false',
     'browserstack.video': 'false'
   },

--- a/index.js
+++ b/index.js
@@ -34,20 +34,20 @@ const browserstackLaunchers = {
     'browserstack.video': 'false'
   },
 
-  bsSafari16: {
+  bsSafari15: {
     'base': 'BrowserStack',
     'browser': 'safari',
     'os': 'OS X',
-    'os_version': 'Ventura',
+    'os_version': 'Monterey',
     'browserstack.local': 'false',
     'browserstack.video': 'false'
   },
 
-  bsSafari14: {
+  bsSafari17: {
     'base': 'BrowserStack',
     'browser': 'safari',
     'os': 'OS X',
-    'os_version': 'Big Sur',
+    'os_version': 'Sonoma',
     'browserstack.local': 'false',
     'browserstack.video': 'false'
   }


### PR DESCRIPTION
Updates Windows to use 11 instead of 10, and updates to running Safari 15 and 17 (Monterey and Sonoma)