### PR TITLE
feat: add chrome 53 browser launcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,6 +220,14 @@ A function that should return an object containing karma custom launchers, that 
     os_version: '10'
   },
 
+  bsChrome53: {
+    base: 'BrowserStack',
+    browser: 'chrome',
+    browser_version: '53',
+    os: 'Windows',
+    os_version: '10'
+  },
+
   bsFirefox: {
     base: 'BrowserStack',
     browser: 'firefox',
@@ -227,34 +235,18 @@ A function that should return an object containing karma custom launchers, that 
     os_version: '10'
   },
 
-  bsSafariSierra: {
+  bsSafari12: {
     base: 'BrowserStack',
     browser: 'safari',
     os: 'OS X',
-    os_version: 'Sierra'
+    os_version: 'Mojave'
   },
 
-  bsEdgeWin10: {
+  bsSafari14: {
     base: 'BrowserStack',
-    browser: 'edge',
-    os: 'Windows',
-    os_version: '10'
-  },
-
-  bsIE11Win10: {
-    base: 'BrowserStack',
-    browser: 'ie',
-    browser_version: '11',
-    os: 'Windows',
-    os_version: '10'
-  },
-
-  bsIE11Win7: {
-    base: 'BrowserStack',
-    browser: 'ie',
-    browser_version: '11',
-    os: 'Windows',
-    os_version: '7'
+    browser: 'safari',
+    os: 'OS X',
+    os_version: 'Big Sur'
   }
 }
 ```
@@ -263,9 +255,9 @@ A function that should return an object containing karma custom launchers, that 
 module.exports = function(config) {
   const options = {
     BrowserstackLaunchers(defaults) {
-      // only test on Edge windows 10
+      // only test on Safari Big Sur
       return {
-        bsEdgeWin10: defaults.bsEdgeWin10;
+        bsEdgeWin10: defaults.bsSafari14;
       };
     }
   };

--- a/index.js
+++ b/index.js
@@ -25,6 +25,16 @@ const browserstackLaunchers = {
     'browserstack.video': 'false'
   },
 
+  bsChrome53: {
+    'base': 'BrowserStack',
+    'browser': 'chrome',
+    'browser_version': '53',
+    'os': 'Windows',
+    'os_version': '10',
+    'browserstack.local': 'false',
+    'browserstack.video': 'false'
+  },
+
   bsFirefox: {
     'base': 'BrowserStack',
     'browser': 'firefox',


### PR DESCRIPTION
Since chrome v53 is still necessary for Smart TV support, we need to run a test suite with that version of chrome. This is the change to add another launcher in our karma config files by default.

NOTE: There will need to be changes in Video.js and VHS to account for this change so tests do not start to fail. I will link these here when they are ready.

This could be a breaking change, as the dependent repos will need to account for using sinon v8 when the Chrome 53 tests are run.